### PR TITLE
Fix midl compiling for users with spaces in names

### DIFF
--- a/midiproc/genmidiproc.bat
+++ b/midiproc/genmidiproc.bat
@@ -13,15 +13,15 @@ EXIT /B
 
 :win32
 ECHO Building win32
-midl -Oicf -W1 -Zp8 /env win32 /protocol dce /app_config /out %~dp0 %~dp0midiproc.idl
+midl -Oicf -W1 -Zp8 /env win32 /protocol dce /app_config /out ""%~dp0\"" ""%~dp0midiproc.idl""
 EXIT /B
 :ia64
 ECHO Building ia64/win64
-midl -Oicf -W1 -Zp8 /env ia64 /protocol dce /app_config /out %~dp0 %~dp0midiproc.idl
+midl -Oicf -W1 -Zp8 /env ia64 /protocol dce /app_config /out ""%~dp0\"" ""%~dp0midiproc.idl""
 EXIT /B
 :amd64
 ECHO Building amd64
-midl -Oicf -W1 -Zp8 /env amd64 /protocol dce /app_config /out %~dp0 %~dp0midiproc.idl
+midl -Oicf -W1 -Zp8 /env amd64 /protocol dce /app_config /out ""%~dp0\"" ""%~dp0midiproc.idl""
 EXIT /B
 
 REM This command should be similar to what was initially used to generate the old midiproc

--- a/midiproc/genmidiprocwin32.bat
+++ b/midiproc/genmidiprocwin32.bat
@@ -1,7 +1,7 @@
 @ECHO OFF
 CALL "%VS140COMNTOOLS%\VsDevCmd.bat"
 ECHO Building win32
-midl -Oicf -W1 -Zp8 /env win32 /protocol dce /app_config /out %~dp0 %~dp0midiproc.idl
+midl -Oicf -W1 -Zp8 /env win32 /protocol dce /app_config /out ""%~dp0\"" ""%~dp0midiproc.idl""
 EXIT /B
 
 REM This command should be similar to what was initially used to generate the old midiproc

--- a/midiproc/genmidiprocx64.bat
+++ b/midiproc/genmidiprocx64.bat
@@ -1,7 +1,7 @@
 @ECHO OFF
 CALL "%VS140COMNTOOLS%\VsDevCmd.bat"
 ECHO Building amd64
-midl -Oicf -W1 -Zp8 /env amd64 /protocol dce /app_config /out %~dp0 %~dp0midiproc.idl
+midl -Oicf -W1 -Zp8 /env amd64 /protocol dce /app_config /out ""%~dp0\"" ""%~dp0midiproc.idl""
 EXIT /B
 
 REM This command should be similar to what was initially used to generate the old midiproc


### PR DESCRIPTION
And also in general fixes if the eternity directory has a parent dir with
spaces. Fixes #149